### PR TITLE
Adding support for More Models/Providers

### DIFF
--- a/PolyAIExample/PolyAIExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PolyAIExample/PolyAIExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/jamesrochabrun/SwiftAnthropic",
       "state" : {
         "branch" : "main",
-        "revision" : "bdf0a66e569fc2455b034ca091b9670a79a33b1f"
+        "revision" : "2bfd7ca13fabc4fbb47c7a97d7a0c1b4831bffd2"
       }
     },
     {
@@ -16,7 +16,7 @@
       "location" : "https://github.com/jamesrochabrun/SwiftOpenAI",
       "state" : {
         "branch" : "main",
-        "revision" : "6f1a8dd2e3de348291c8565e04ef2bb59c4a8a0e"
+        "revision" : "e589864f644f10e5a7868174208d414f06a0d27c"
       }
     }
   ],

--- a/PolyAIExample/PolyAIExample/ApiKeysIntroView.swift
+++ b/PolyAIExample/PolyAIExample/ApiKeysIntroView.swift
@@ -13,10 +13,15 @@ struct ApiKeyIntroView: View {
    @State private var anthropicAPIKey = ""
    @State private var openAIAPIKey = ""
    @State private var geminiAPIKey = ""
+   @State private var groqAPIKey = ""
+   @State private var openRouterAPIKey = ""
    @State private var ollamaLocalHostURL = ""
+   
    @State private var anthropicConfigAdded: Bool = false
    @State private var openAIConfigAdded: Bool = false
    @State private var ollamaConfigAdded: Bool = false
+   @State private var groqConfigAdded: Bool = false
+   @State private var openRouterConfigAdded: Bool = false
    @State private var geminiConfigAdded: Bool = false
 
    @State private var configurations: [LLMConfiguration] = []
@@ -46,19 +51,31 @@ struct ApiKeyIntroView: View {
                   provider: "Gemini",
                   configurationAdded: $geminiConfigAdded,
                   apiKey: $geminiAPIKey) {
-                     configurations.append(.gemini(apiKey: geminiAPIKey))
+                     configurations.append(.openAI(.gemini(apiKey: geminiAPIKey)))
+                  }
+               LLMConfigurationView(
+                  provider: "Groq",
+                  configurationAdded: $groqConfigAdded,
+                  apiKey: $groqAPIKey) {
+                     configurations.append(.openAI(.groq(apiKey: groqAPIKey)))
+                  }
+               LLMConfigurationView(
+                  provider: "OpenRouter",
+                  configurationAdded: $openRouterConfigAdded,
+                  apiKey: $openRouterAPIKey) {
+                     configurations.append(.openAI(.openRouter(apiKey: openRouterAPIKey)))
                   }
                LLMConfigurationView(
                   provider: "Ollama",
                   configurationAdded: $ollamaConfigAdded,
                   apiKey: $ollamaLocalHostURL) {
-                     configurations.append(.ollama(url: ollamaLocalHostURL))
+                     configurations.append(.openAI(.ollama(url: ollamaLocalHostURL)))
                   }
             }
             .buttonStyle(.bordered)
             .padding()
             .textFieldStyle(.roundedBorder)
-            NavigationLink(destination: OptionsListView(service: PolyAIServiceFactory.serviceWith(configurations))) {
+            NavigationLink(destination: OptionsListView(service: PolyAIServiceFactory.serviceWith(configurations, debugEnabled: true))) {
                Text("Continue")
                   .padding()
                   .padding(.horizontal, 48)

--- a/PolyAIExample/PolyAIExample/MessageDemoView.swift
+++ b/PolyAIExample/PolyAIExample/MessageDemoView.swift
@@ -25,6 +25,9 @@ struct MessageDemoView: View {
       case anthropic
       case gemini
       case llama3
+      case groq
+      case openRouter
+      case deepSeek
       
       var id: String { rawValue }
    }
@@ -71,6 +74,24 @@ struct MessageDemoView: View {
                      messages: [
                         .init(role: .user, content: prompt)
                      ])
+               case .groq:
+                  parameters = .groq(
+                     model: "deepseek-r1-distill-llama-70b",
+                     messages: [
+                        .init(role: .user, content: prompt)
+                     ])
+               case .deepSeek:
+                  parameters = .deepSeek(
+                     model: "deepseek-reasoner",
+                     messages: [
+                        .init(role: .user, content: prompt)
+                     ])
+               case .openRouter:
+                  parameters = .openRouter(
+                     model: "deepseek/deepseek-r1:free",
+                     messages: [
+                        .init(role: .user, content: prompt)
+                     ])
                case .anthropic:
                   parameters = .anthropic(
                      model: .claude3Sonnet,
@@ -96,6 +117,7 @@ struct MessageDemoView: View {
          } label: {
             Image(systemName: "paperplane")
          }
+         .keyboardShortcut(.return)
          .buttonStyle(.bordered)
       }
       .padding()

--- a/Sources/PolyAI/Interfaces/Parameters/LLMParameter.swift
+++ b/Sources/PolyAI/Interfaces/Parameters/LLMParameter.swift
@@ -19,6 +19,48 @@ public enum LLMParameter {
      ///   - maxTokens: An optional maximum number of tokens to generate. Defaults to `nil`.
    case openAI(model: SwiftOpenAI.Model, messages: [LLMMessage], maxTokens: Int? = nil)
    
+   /// Represents a configuration for interacting with OpenAI's models.
+     /// - Parameters:
+     ///   - model: The specific model of OpenAI to use.
+     ///   - messages: An array of messages to send to the model.
+     ///   - maxTokens: An optional maximum number of tokens to generate. Defaults to `nil`.
+   case azure(model: SwiftOpenAI.Model, messages: [LLMMessage], maxTokens: Int? = nil)
+   
+   /// Represents a configuration for interacting with OpenAI's models.
+     /// - Parameters:
+     ///   - model: The specific model of OpenAI to use.
+     ///   - messages: An array of messages to send to the model.
+     ///   - maxTokens: An optional maximum number of tokens to generate. Defaults to `nil`.
+   case aiProxy(model: SwiftOpenAI.Model, messages: [LLMMessage], maxTokens: Int? = nil)
+   
+   /// Represents a configuration for interacting with Gemini's models.
+     /// - Parameters:
+     ///  - model: The specific model of Gemini to use.
+     ///  - messages: An array of messages to send to the model.
+     ///  - maxTokens: The maximum number of tokens to generate.
+   case gemini(model: String, messages: [LLMMessage], maxTokens: Int? = nil)
+   
+   /// Represents a configuration for interacting with Groq''s models.
+     /// - Parameters:
+     ///  - model: The specific model of Groq to use.
+     ///  - messages: An array of messages to send to the model.
+     ///  - maxTokens: The maximum number of tokens to generate.
+   case groq(model: String, messages: [LLMMessage], maxTokens: Int? = nil)
+   
+   /// Represents a configuration for interacting with DeepSeek's models.
+     /// - Parameters:
+     ///  - model: The specific model of DeepSeek to use.
+     ///  - messages: An array of messages to send to the model.
+     ///  - maxTokens: The maximum number of tokens to generate.
+   case deepSeek(model: String, messages: [LLMMessage], maxTokens: Int? = nil)
+   
+   /// Represents a configuration for interacting with OpenRouter's models.
+   /// - Parameters:
+   ///   - model: The specific model of OpenRouter to use.
+   ///   - messages: An array of messages to send to the model.
+   ///   - maxTokens: The maximum number of tokens to generate.
+   case openRouter(model: String, messages: [LLMMessage], maxTokens: Int? = nil)
+   
    /// Represents a configuration for interacting with Anthropic's models.
    /// - Parameters:
    ///   - model: The specific model of Anthropic to use.
@@ -26,14 +68,7 @@ public enum LLMParameter {
    ///   - maxTokens: The maximum number of tokens to generate.
    case anthropic(model: SwiftAnthropic.Model, messages: [LLMMessage], maxTokens: Int)
    
-   /// Represents a configuration for interacting with Gemini's models.
-   /// - Parameters:
-   ///   - model: The specific model of Gemini to use.
-   ///   - messages: An array of messages to send to the model.
-   ///   - maxTokens: The maximum number of tokens to generate.
-   case gemini(model: String, messages: [LLMMessage], maxTokens: Int? = nil)
-   
-   /// Represents a configuration for interacting with Gemini's models.
+   /// Represents a configuration for interacting with Ollama's models.
    /// - Parameters:
    ///   - model: The specific model. e.g: "llama3"
    ///   - messages: An array of messages to send to the model.
@@ -47,6 +82,11 @@ public enum LLMParameter {
       case .anthropic: return "Anthropic"
       case .gemini: return "Gemini"
       case .ollama(let model, _, _): return model
+      case .azure: return "Azure"
+      case .aiProxy: return "AIProxy"
+      case .groq: return "Groq"
+      case .deepSeek: return "DeepSeek"
+      case .openRouter: return "OpenRouter"
       }
    }
 }

--- a/Sources/PolyAI/Interfaces/Response/Message/LLMMessageResponse+Anthropic.swift
+++ b/Sources/PolyAI/Interfaces/Response/Message/LLMMessageResponse+Anthropic.swift
@@ -19,7 +19,7 @@ extension MessageResponse: LLMMessageResponse {
    public var contentDescription: String {
       content.map { contentItem in
          switch contentItem {
-         case .text(let text):
+         case .text(let text, _):
             return text
          case .toolUse(let toolUSe):
             return "Tool: \(toolUSe.name)"

--- a/Sources/PolyAI/Service/PolyAIService.swift
+++ b/Sources/PolyAI/Service/PolyAIService.swift
@@ -11,9 +11,9 @@ import SwiftOpenAI
 /// Represents configurations for different LLM providers.
 public enum LLMConfiguration {
 
-   case openAI(OpenAI)
+   case openAI(OpenAICompatible)
    
-   public enum OpenAI {
+   public enum OpenAICompatible {
       /// Configuration for accessing OpenAI's API.
       /// - Parameters:
       ///   - apiKey: The API key for authenticating requests to OpenAI.
@@ -35,6 +35,35 @@ public enum LLMConfiguration {
       ///                      with, you can pass a clientID here. If you do not have existing client or user IDs, leave
       ///                      the `clientID` argument out, and IDs will be generated automatically for you.
       case aiProxy(aiproxyPartialKey: String, aiproxyClientID: String? = nil)
+      /// Configuration for accessing Gemini's API.
+      /// - Parameters:
+      ///   - apiKey: The API key for authenticating requests to Gemini.
+      ///   - urlSessionConfiguration: The URLSession configuration to use for network requests. Defaults to `.default`.
+      ///   - decoder: The JSON decoder used for decoding responses. Defaults to a new instance of `JSONDecoder`.
+      case gemini(apiKey: String, configuration: URLSessionConfiguration = .default, decoder: JSONDecoder = .init())
+      /// Configuration for accessing Groq's API.
+      /// - Parameters:
+      ///   - apiKey: The API key for authenticating requests to Gemini.
+      ///   - urlSessionConfiguration: The URLSession configuration to use for network requests. Defaults to `.default`.
+      ///   - decoder: The JSON decoder used for decoding responses. Defaults to a new instance of `JSONDecoder`.
+      case groq(apiKey: String, configuration: URLSessionConfiguration = .default, decoder: JSONDecoder = .init())
+      /// Configuration for accessing DeepSeek''s API.
+      /// - Parameters:
+      ///   - apiKey: The API key for authenticating requests to Gemini.
+      ///   - urlSessionConfiguration: The URLSession configuration to use for network requests. Defaults to `.default`.
+      ///   - decoder: The JSON decoder used for decoding responses. Defaults to a new instance of `JSONDecoder`.
+      case deepSeek(apiKey: String, configuration: URLSessionConfiguration = .default, decoder: JSONDecoder = .init())
+      /// Configuration for accessing Groq's API.
+      /// - Parameters:
+      ///   - apiKey: The API key for authenticating requests to OpenRouter.
+      ///   - urlSessionConfiguration: The URLSession configuration to use for network requests. Defaults to `.default`.
+      ///   - decoder: The JSON decoder used for decoding responses. Defaults to a new instance of `JSONDecoder`.
+      ///   - extraHeaders: Optional. Site URL  and title for rankings on openrouter.ai
+      case openRouter(apiKey: String, configuration: URLSessionConfiguration = .default, decoder: JSONDecoder = .init(), extraHeaders: [String: String]? = nil)
+      /// Configuration for accessing Ollama models using OpenAI endpoints compatibility.
+      /// - Parameters:
+      ///   - url: The local host URL. e.g "http://localhost:11434"
+      case ollama(url: String)
    }
    
    /// Configuration for accessing Anthropic's API.
@@ -43,24 +72,16 @@ public enum LLMConfiguration {
    ///   - configuration: The URLSession configuration to use for network requests. Defaults to `.default`.
    ///   - betaHeaders: An array of headers for Anthropic's beta features.
    case anthropic(apiKey: String, configuration: URLSessionConfiguration = .default, betaHeaders: [String]? = nil)
-   
-   /// Configuration for accessing Gemini's API.
-   /// - Parameters:
-   ///   - apiKey: The API key for authenticating requests to Gemini.
-   case gemini(apiKey: String)
-   
-   /// Configuration for accessing Ollama models using OpenAI endpoints compatibility.
-   /// - Parameters:
-   ///   - url: The local host URL. e.g "http://localhost:11434"
-   case ollama(url: String)
 }
 
 /// Defines the interface for a service that interacts with Large Language Models (LLMs).
 public protocol PolyAIService {
 
    /// Initializes a new instance with the specified configurations for LLM providers.
-   /// - Parameter configurations: An array of `LLMConfiguration` items, each specifying settings for a different LLM provider.
-   init(configurations: [LLMConfiguration])
+   /// - Parameters:
+   ///  - configurations: An array of `LLMConfiguration` items, each specifying settings for a different LLM provider.
+   ///  - debugEnabled: Logs requests if `true`
+   init(configurations: [LLMConfiguration], debugEnabled: Bool)
    
    // MARK: Message
 
@@ -81,4 +102,24 @@ public protocol PolyAIService {
    func streamMessage(
       _ parameter: LLMParameter)
    async throws -> AsyncThrowingStream<LLMMessageStreamResponse, Error>
+}
+
+extension LLMConfiguration {
+   
+   public var rawValue: String {
+      switch self {
+      case .openAI(let openAICompatible):
+         switch openAICompatible {
+         case .api: "OpenAI"
+         case .azure: "Azure"
+         case .aiProxy: "AiProxy"
+         case .gemini: "Gemini"
+         case .groq: "Groq"
+         case .ollama: "Ollama"
+         case .openRouter: "OpenRouter"
+         case .deepSeek: "DeepSeek"
+         }
+      case .anthropic: "Anthropic"
+      }
+   }
 }

--- a/Sources/PolyAI/Service/PolyAIServiceFactory.swift
+++ b/Sources/PolyAI/Service/PolyAIServiceFactory.swift
@@ -10,9 +10,10 @@ import Foundation
 public struct PolyAIServiceFactory {
    
    public static func serviceWith(
-      _ configurations: [LLMConfiguration])
+      _ configurations: [LLMConfiguration],
+      debugEnabled: Bool = false)
       -> PolyAIService
    {
-      DefaultPolyAIService(configurations: configurations)
+      DefaultPolyAIService(configurations: configurations, debugEnabled: debugEnabled)
    }
 }


### PR DESCRIPTION
- Added support for DeepSeek
- Added support for Groq
- Added support for OpenRouter

```swift
      /// Configuration for accessing Groq's API.
      /// - Parameters:
      ///   - apiKey: The API key for authenticating requests to Gemini.
      ///   - urlSessionConfiguration: The URLSession configuration to use for network requests. Defaults to `.default`.
      ///   - decoder: The JSON decoder used for decoding responses. Defaults to a new instance of `JSONDecoder`.
      case groq(apiKey: String, configuration: URLSessionConfiguration = .default, decoder: JSONDecoder = .init())
      /// Configuration for accessing DeepSeek''s API.
      /// - Parameters:
      ///   - apiKey: The API key for authenticating requests to DeepSeek.
      ///   - urlSessionConfiguration: The URLSession configuration to use for network requests. Defaults to `.default`.
      ///   - decoder: The JSON decoder used for decoding responses. Defaults to a new instance of `JSONDecoder`.
      case deepSeek(apiKey: String, configuration: URLSessionConfiguration = .default, decoder: JSONDecoder = .init())
      /// Configuration for accessing Groq's API.
      /// - Parameters:
      ///   - apiKey: The API key for authenticating requests to OpenRouter.
      ///   - urlSessionConfiguration: The URLSession configuration to use for network requests. Defaults to `.default`.
      ///   - decoder: The JSON decoder used for decoding responses. Defaults to a new instance of `JSONDecoder`.
      ///   - extraHeaders: Optional. Site URL  and title for rankings on openrouter.ai
      case openRouter(apiKey: String, configuration: URLSessionConfiguration = .default, decoder: JSONDecoder = .init(), extraHeaders: 
```